### PR TITLE
Don't use ⌘; which is system wide Check Spell

### DIFF
--- a/Commands/Complete across current open files.tmCommand
+++ b/Commands/Complete across current open files.tmCommand
@@ -43,7 +43,7 @@ end
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@;</string>
+	<string>^</string>
 	<key>name</key>
 	<string>Complete across current tabs</string>
 	<key>outputCaret</key>


### PR DESCRIPTION
Instead use ⌃⎋ which is just like other completions but with ⌃ modifier.

Reason being is that latest TM2 has finally implemented Check Spell functionality, and not this shortcut clashes with built-in shortcut.
