### PR TITLE
Fix - in cross tab completition all choices from one file were joined in...

### DIFF
--- a/Commands/Complete across current open files.tmCommand
+++ b/Commands/Complete across current open files.tmCommand
@@ -31,7 +31,7 @@ end.map {|t| t.join; t.value}
 
 @loader.join
 
-choices.uniq!
+choices.flatten!.uniq!
 if choices.size == 1
   print choices.first[current_word.size..-1]
 else


### PR DESCRIPTION
Error was introduced with use thread for completions.
Before:

``` ruby
choices = []
['a','b'].each do |name|
  choices += [name, 'c'].flatten
end
choices.inspect # => ['a', 'c', 'b', 'c']
```

After threads:

``` ruby
choices = ['a','b'].map do |name|\
  [name, 'c'].flatten
end
choices.inspect # => [["a", "c"], ["b", "c"]]
```
