### PR TITLE
Ensure text highlight color is preserved for reference file

### DIFF
--- a/Support/lib/doctohtml.rb
+++ b/Support/lib/doctohtml.rb
@@ -19,12 +19,12 @@ def theme_plist
 end
 
 def to_rgba(color)
-	colors = color.scan /^#(..)(..)(..)(..)/
-	r = colors[0][0].hex
-	g = colors[0][1].hex
-	b = colors[0][2].hex
-	a = colors[0][3].hex
-	return "rgba(#{r}, #{g}, #{b}, #{ format '%0.02f', a / 255.0 })"
+  colors = color.scan /^#(..)(..)(..)(..)?/
+  r = colors[0][0].hex
+  g = colors[0][1].hex
+  b = colors[0][2].hex
+  a = colors[0][3] ? colors[0][3].hex : 253
+  return "rgba(#{r}, #{g}, #{b}, #{ format '%0.02f', a / 255.0 })"
 end
 
 def generate_stylesheet_from_theme(theme_class = nil)
@@ -75,7 +75,12 @@ def generate_stylesheet_from_theme(theme_class = nil)
 			selection_bg = setting['settings']['selection']
 			body_bg = to_rgba(body_bg) if body_bg =~ /#.{8}/
 			body_fg = to_rgba(body_fg) if body_fg =~ /#.{8}/
-			selection_bg = to_rgba(selection_bg) if selection_bg && selection_bg =~ /#.{8}/
+			# Force the selection background to be rgba. If solid, will generate
+			# (e.g.) "rgba(63, 63, 63, 0.99)"; specifying the alpha value is
+			# required because WebKit will apply a default alpha of 0.5 to the
+			# `::selection` pseudo-element.
+			# See: http://stackoverflow.com/questions/7224445/css3-selection-behaves-differently-in-ff-chrome
+			selection_bg = to_rgba(selection_bg) if selection_bg
 			next
 		end
 		next unless setting['name'] and setting['scope']


### PR DESCRIPTION
In WebKit, the `::selection` pseudo-selector applies a ~0.5 opacity to the specified `background-color`. This means that in the HTML generated for for the "Keep current file as reference" command, the text highlight is far fainter than it should be. On my theme, it was almost invisible, and it made text search (with cmd-F) much harder because I couldn't see what was highlighted.

[The fix](http://stackoverflow.com/questions/7224445/css3-selection-behaves-differently-in-ff-chrome/7224621#7224621) is to specify the `background-color` as `rgba` with an opacity of `0.99`.
