### PR TITLE
Support OS X 10.10

### DIFF
--- a/Commands/Align column assignments.tmCommand
+++ b/Commands/Align column assignments.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
+	<string>#!/usr/bin/ruby
 #
 # Assignment block tidier, version 0.1.
 #

--- a/Commands/Complete across current open files.tmCommand
+++ b/Commands/Complete across current open files.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 
 @loader = Thread.new { require ENV['TM_SUPPORT_PATH'] + '/lib/ui.rb' }
 

--- a/Commands/Open file as reference.tmCommand
+++ b/Commands/Open file as reference.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -rjcode -Ku
+	<string>#!/usr/bin/env ruby18 -rjcode -Ku
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/doctohtml.rb"
 require "#{ENV['TM_SUPPORT_PATH']}/lib/progress.rb"

--- a/Commands/Open global _tm_properties.tmCommand
+++ b/Commands/Open global _tm_properties.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+	<string>#!/usr/bin/ruby -wKU
 
 path = File.expand_path('~/.tm_properties')
 system 'touch', path

--- a/Commands/Open prject _tm_properties.tmCommand
+++ b/Commands/Open prject _tm_properties.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+	<string>#!/usr/bin/ruby
 project_dir = ENV['TM_PROJECT_DIRECTORY']
 
 unless project_dir

--- a/Commands/Save Project.tmCommand
+++ b/Commands/Save Project.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+	<string>#!/usr/bin/ruby -wKU
 
 # TM_PROPERTIES
 

--- a/Commands/Strip trailing whitespace on save.tmCommand
+++ b/Commands/Strip trailing whitespace on save.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+	<string>#!/usr/bin/ruby -wKU
 
 content = STDIN.read
 


### PR DESCRIPTION
Hi Elia,

the following commit adds support for OS X 10.10 to the bundle. I tested all commands under OS X Yosemite Beta 3 and TextMate 2.0-alpha.9565. They all seem to work fine.

By the way: Do you have an example text snippet to show the correct behaviour of “Align column assignment”. The documentation for the command is the same as the one included in the Source bundle, but while I am able to align the following text with the “Align column assignment” command provided by the Source bundle, the command included in this bundle does not seem to align anything at all.

```
1 + 1 = 2
10 + 10 = 20
```

Kind regards,
  René
